### PR TITLE
EQNexus: Update config.json and include in required files

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
         "66.70.227.48"
     ],
     "required": [
-        "dinput8.dll"
+        "dinput8.dll",
+        "config.json"
     ],
     "files": {}
 }

--- a/rof/config.json
+++ b/rof/config.json
@@ -13,6 +13,15 @@
         "disableMapWindow": false,
         "disableLuclinModels": false,
         "disabledBazaarWindow": false,
-        "disableHeroic": false
+        "disableHeroic": false,
+        "disableFoodDrinkSpam": false,
+        "enableMaxHPFix": false,
+        "enableAnyClassShield": false,
+        "enableCombatDamageDoubleAppliedFix": false,
+        "enableUltravision": false,
+        "enableOldModelHorseSupport": false
+    },
+    "server": {
+        "customFilesKey": "theheroesjourney"
     }
 }


### PR DESCRIPTION
Adding config.json to required files means it's *impossible for users to modify this and log into the game, by changing options like `disallowMq2` or the like.

Also added the clientside option that sends a custom payload on world login that matches to this PR in eqemu: https://github.com/EQEmu/Server/pull/4561

If THJ wants to eventually deprecate all patch paths except nexus, this would be the way to do it