### PR TITLE
Clarity for Fennin Ro event: fire minis are not required

### DIFF
--- a/rof/storyline/PlanarProgression/storyplaneoffire.txt
+++ b/rof/storyline/PlanarProgression/storyplaneoffire.txt
@@ -5,22 +5,9 @@
 While killing trash, look for <c "#ffd700">Solidified Magma</c> and <c "#ffd700">Fiery Granite</c>.<br>
 One each of these will be needed later to craft the <c "#35db24">Plane of Time</c> key.<br><br>
 
+<c "#35db24"> Clearing to Fennin Ro</c><br>
+This is a 4 phase event followed by <c "#ff0000">Fennin Ro</c> himself. Make your way to the back of the castle on the south side of the zone.<br><br>
 
-<c "#35db24"> Part One - Mini Bosses</c><br>
-Another straight forward zone. Make your way thru the zone killing mobs. Along the way you will face several named mobs.<br>
-<c "#ff0000">
-General Druav Flamesinger<br>
-Jaxoliz Dawneyes<br>
-Criare Sunmane<br>
-Quavonis Firetail<br>
-Magmaton<br>
-Babnoxis, the Spider Queen<br>
-Pyronis<br>
-Blazzax the Omnifiend<br>
-General Reparm<br></c>
-and finally <c "#ff0000">Arch Mage Yozanni</c><br><br>
-
-<c "#35db24"> Part Two - Clearing to Fennin Ro</c><br><br>
       <c "#35db24"> Phase One - Guardian of Doomfire</c><br>
 Kill <c "#ff0000">Guardian of Doomfire</c> to start the event<br><br>
       <c "#35db24"> Phase Two - Named Wave One</c><br>


### PR DESCRIPTION
I've seen a number of times that people are confused by the way this story is written because it mentions the minibosses, but they are not part of progression/flagging. I was confused by it myself the first time I went through.

So, I took that section out and added a line that I lifted from the Coirnav story to make it consistent.

This is the type of confusion I'm trying to resolve:

![image](https://github.com/user-attachments/assets/630efa12-f204-4794-998a-a6784790e5ff)
![image](https://github.com/user-attachments/assets/d9599d27-32f2-4198-a08d-b02f09c11d4f)
