### PR TITLE
Remove incorrect storylines about EP boss timers

### DIFF
--- a/rof/storyline/PlanarProgression/storyplaneofearthb.txt
+++ b/rof/storyline/PlanarProgression/storyplaneofearthb.txt
@@ -21,7 +21,7 @@ Kill <c "#ff0000">Warlord Gintolaken</c> becomes targetable once the three War C
 <c "#35db24">The Rathe Council</c><br><br>
 ***Subject to change on THJ***<br>
 There are a total of 12 Rathe Council members. 6 of them are mezzable and 6 of them are rootable.<br>
-You must kill all of the <c "#ff0000">Rathe Councilman</c> within approx 6 minutes of each other or the event will fail!<br><br>
+This event has no time limit.<br><br>
 
 <c "#35db24">The Avatar of Earth</c><br><br>
 Once all of the councilmen are dead, <c "#ff0000">The Avatar of Earth</c> spawns. Killing him will complete this zone.<br>

--- a/rof/storyline/PlanarProgression/storyplaneofwater.txt
+++ b/rof/storyline/PlanarProgression/storyplaneofwater.txt
@@ -8,7 +8,7 @@ One each of these will be needed later to craft the Plane of Time key.<br><br>
 
 
 <c "#ff0000">Coirnav</c> is a 4 wave fight followed by <c "#ff0000">Coirnav</c> himself.<br>
-This event has no time limit in a respawning instance.<br><br>
+This event has no time limit in a non-respawning instance.<br><br>
 
 <c "#35db24"> Wave One</c><br><br>
 Engage <c "#ff0000">Guardian of Coirnav</c>, and once he dies <c "#ff0000">Pwelon of Vapor</c> will spawn along with 20-25 <c "#ff0000">vaporfiend</c> adds.<br>Kill all of this to start wave two.<br><br>

--- a/rof/storyline/PlanarProgression/storyplaneofwater.txt
+++ b/rof/storyline/PlanarProgression/storyplaneofwater.txt
@@ -8,7 +8,7 @@ One each of these will be needed later to craft the Plane of Time key.<br><br>
 
 
 <c "#ff0000">Coirnav</c> is a 4 wave fight followed by <c "#ff0000">Coirnav</c> himself.<br>
-At the start of this fight, a 15 minute timer begins. You must have all of the guards killed within this 15 minutes or the event will fail.<br><br>
+This event has no time limit in a respawning instance.<br><br>
 
 <c "#35db24"> Wave One</c><br><br>
 Engage <c "#ff0000">Guardian of Coirnav</c>, and once he dies <c "#ff0000">Pwelon of Vapor</c> will spawn along with 20-25 <c "#ff0000">vaporfiend</c> adds.<br>Kill all of this to start wave two.<br><br>


### PR DESCRIPTION
* Rathe Council has no time limit. There is code for a timer but it is explicitly disabled, ref: https://github.com/The-Heroes-Journey-EQEMU/quests_public/blob/staging/poearthb/%23rathe_controller.lua#L8
* Coirnav does have a time limit in OW (20 minutes, not 15), but not in an instance. So, added a note that better reflects how it works, ref: https://github.com/The-Heroes-Journey-EQEMU/quests_public/blob/4c2dd99f52f78af4b29485be3ee3c9d840a27964/powater/%23coirnav_controller.pl#L137

Example confusion in game on the POEB side:

![image](https://github.com/user-attachments/assets/8c6db16a-0614-45f8-9d7d-2a351a468a7d)
