### PR TITLE
Remove out of bounds environment emitters

### DIFF
--- a/rof/bazaar_EnvironmentEmitters.txt
+++ b/rof/bazaar_EnvironmentEmitters.txt
@@ -1,0 +1,1 @@
+Name^EmitterDefIdx^X^Y^Z^Lifespan


### PR DESCRIPTION
Removed environment emitters leftover from new version of bazaar that never got removed when old bazaar was restored. These are suspected to be causing crashes for some players in bazaar. They were out of bounds of the zone geometry of old bazaar so nobody ever saw them anyway but the client was still loading them.

Discord bug thread reference: https://discord.com/channels/1204418766318862356/1370449345979089147